### PR TITLE
Feature: Enable logging to Weights & Biases

### DIFF
--- a/scripts/learn_subword.sh
+++ b/scripts/learn_subword.sh
@@ -5,7 +5,7 @@ data_path=$1
 vocab_size=$2
 output_path=$3
 
-train_data_path=${data_path}/train/all_train.txt
+train_data_path=${data_path}/all_train.txt
 output_path=${output_path}
 
 mkdir -p $output_path

--- a/src/trainer.py
+++ b/src/trainer.py
@@ -467,7 +467,7 @@ def write_train_metric(train_metrics, train_time, step, writer_type: str, summar
         assert summary_writer is not None
         summary_writer.scalar("train_time", train_time, step)
     elif writer_type == "wandb":
-        wandb.log({"train_time": train_time}, step=step)
+        wandb.log({"train_time": train_time}, step=step, commit=False)
     # else:
     #    logger.warning("Train Metrics could not be written. Supported `writer_type` are wandb & tensorboard")
 
@@ -478,9 +478,10 @@ def write_train_metric(train_metrics, train_time, step, writer_type: str, summar
         
         for i, val in enumerate(vals):
             if writer_type == "tensorboard":
-                summary_writer.scalar(tag, val, step=step-len(vals)+1)
+                assert summary_writer is not None
+                summary_writer.scalar(tag, val, step=step - len(vals) + i + 1)
             elif writer_type == "wandb":
-                wandb.log({tag: val}, step=step-len(vals)+1)
+                wandb.log({tag: val}, step=step - len(vals) + i + 1, commit=False if cur_step % training_args.eval_steps == 0 else True)
 
 
 def write_eval_metric(eval_metrics, step, writer_type: str, summary_writer=None):
@@ -489,7 +490,7 @@ def write_eval_metric(eval_metrics, step, writer_type: str, summary_writer=None)
             assert summary_writer is not None
             summary_writer.scalar(f"eval/{metric_name}", value, step)
         elif writer_type == "wandb":
-            wandb.log({f"eval/{metric_name}": value}, step=step)
+            wandb.log({f"eval/{metric_name}": value}, step=step, commit=True)
         # else:
         #    logger.warning("Eval Metrics could not be written. Supported `writer_type` are wandb & tensorboard")
 

--- a/src/trainer.py
+++ b/src/trainer.py
@@ -474,7 +474,7 @@ def write_train_metric(train_metrics, train_time, step, writer_type: str, eval_s
 
     train_metrics = get_metrics(train_metrics)
 
-    for key, vals in train_metrics.items():
+    for metric_idx, (key, vals) in enumerate(train_metrics.items()):
         tag = f"train/{key}"
         
         for i, val in enumerate(vals):
@@ -482,7 +482,9 @@ def write_train_metric(train_metrics, train_time, step, writer_type: str, eval_s
                 assert summary_writer is not None
                 summary_writer.scalar(tag, val, step=step - len(vals) + i + 1)
             elif writer_type == "wandb":
-                wandb.log({tag: val}, step=step - len(vals) + i + 1, commit=False if step % eval_steps == 0 else True)
+                wandb.log(
+                     {tag: val}, step=step - len(vals) + i + 1, 
+                     commit=True if (metric_idx+1 == len(train_metrics)) and (step % eval_steps != 0) else False)
 
 
 def write_eval_metric(eval_metrics, step, writer_type: str, summary_writer=None):

--- a/train.sh
+++ b/train.sh
@@ -6,6 +6,9 @@
 #SBATCH --account=def-kshook
 #SBATCH -o logs/train_afrit5_base_am_ha_sw.log
 
-nvidia-smi
+# nvidia-smi
+export WANDB_MODE="online"
+export WANDB_ENTITY="jarmy-naija"
+export WANDB_PROJECT="afriteva-v2"
 
-python3 src/trainer.py training_configs/t5_large.json
+python3 src/trainer.py training_configs/t5_base.json


### PR DESCRIPTION
- W&B is now initialized by default at the top of the training script (src/trainer.py). This can be made more flexible using the `report_to` CLI arg.  
- Modified metric writing functions to use either Tensorboard SummaryWriter or W&B logger. 
